### PR TITLE
Add custom style attribute

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -3,10 +3,16 @@ import ReactDOM from 'react-dom';
 
 import ReactSVG from '../lib';
 
+var styles = {
+  height: '100px',
+  width: '100px'
+}
+
 ReactDOM.render(
   <ReactSVG
     path={'atomic.svg'}
     className={'example'}
+    style={styles}
     callback={(svg) => console.log(svg)}
   />,
   document.querySelector('.Root')

--- a/example/index.js
+++ b/example/index.js
@@ -3,16 +3,11 @@ import ReactDOM from 'react-dom';
 
 import ReactSVG from '../lib';
 
-var styles = {
-  height: '100px',
-  width: '100px'
-}
-
 ReactDOM.render(
   <ReactSVG
     path={'atomic.svg'}
     className={'example'}
-    style={styles}
+    style={{height: '200px', width: '200px'}}
     callback={(svg) => console.log(svg)}
   />,
   document.querySelector('.Root')

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,6 @@ export default class ReactSVG extends Component {
   static propTypes = {
     path: PropTypes.string.isRequired,
     className: PropTypes.string,
-    height: PropTypes.string,
     style: PropTypes.object,
     evalScripts: PropTypes.oneOf(['always', 'once', 'never']),
     fallbackPath: PropTypes.string,

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,8 @@ export default class ReactSVG extends Component {
   static propTypes = {
     path: PropTypes.string.isRequired,
     className: PropTypes.string,
+    height: PropTypes.string,
+    style: PropTypes.object,
     evalScripts: PropTypes.oneOf(['always', 'once', 'never']),
     fallbackPath: PropTypes.string,
     callback: PropTypes.func
@@ -21,6 +23,7 @@ export default class ReactSVG extends Component {
     const {
       className,
       path,
+      style,
       fallbackPath
     } = this.props;
 
@@ -28,6 +31,7 @@ export default class ReactSVG extends Component {
       <img
         className={className}
         data-src={path}
+        style={style}
         data-fallback={fallbackPath}
         ref={(img) => this._img = img}
       />


### PR DESCRIPTION
Add style attribute in the react component to customize the svg element. 
This could be previously done only by className attribute.
I tend to use style attribute instead of class attribute with CSS.

I checked that SVGInjector correctly accepts style attribute and it does.